### PR TITLE
Fix Building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,13 @@ COPY requirements.txt /opt/pluto-deliverables/requirements.txt
 ADD gnmvidispine /tmp/gnmvidispine
 WORKDIR /opt/pluto-deliverables
      #workaround for build issues on Mac
-RUN  cp /etc/resolv.conf /etc/resolv.conf.bak && echo nameserver 8.8.8.8 > /etc/resolv.conf && \
-     apk add --no-cache alpine-sdk linux-headers openssl-dev libffi-dev mailcap postgresql-dev postgresql-libs && \
+RUN apk add --no-cache alpine-sdk linux-headers openssl-dev libffi-dev mailcap postgresql-dev postgresql-libs && \
     pip install -r /tmp/gnmvidispine/requirements.txt && \
     cd /tmp/gnmvidispine && python /tmp/gnmvidispine/setup.py install && cd /opt/pluto-deliverables && \
     pip install -r requirements.txt uwsgi && \
     rm -rf /root/.cache && \
     rm -rf /tmp/gnmvidispine && \
-    apk --no-cache del alpine-sdk linux-headers openssl-dev libffi-dev postgresql-dev && \
-    cat /etc/resolv.conf.bak  > /etc/resolv.conf && rm -f /etc/resolv.conf.bak
+    apk --no-cache del alpine-sdk linux-headers openssl-dev libffi-dev postgresql-dev
 COPY manage.py /opt/pluto-deliverables/manage.py
 ADD --chown=nobody:root gnm_deliverables /opt/pluto-deliverables/gnm_deliverables/
 ADD --chown=nobody:root rabbitmq /opt/pluto-deliverables/rabbitmq/

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ django-nose==1.4.6
 coverage==5.2.1
 psycopg2==2.8.5
 pika==1.1.0
-PyYAML==5.4
+PyYAML==6.0.1
 certifi==2020.4.5.1
 PyJWT==2.4.0
 cryptography==3.3.2


### PR DESCRIPTION
## What does this change?

Moves PyYAML from version 5.4 to version 6.0.1 to allow the software to build.

## How can we measure success?

The software builds successfully.

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2.