### PR TITLE
Use New Type

### DIFF
--- a/rabbitmq/AtomResponderProcessor.py
+++ b/rabbitmq/AtomResponderProcessor.py
@@ -85,7 +85,7 @@ class AtomResponderProcessor(MessageProcessor):
         timestamp = timezone.localize(datetime.now()).isoformat()
 
         asset = DeliverableAsset(
-            type=AssetChoices.DELIVERABLE_ASSET_TYPE_VIDEO_FULL_MASTER,
+            type=AssetChoices.DELIVERABLE_ASSET_TYPE_VIDEO_PUBLISHED_ATOM_FILE,
             atom_id=atomid,
             deliverable=bundle,
             changed_dt=timestamp,


### PR DESCRIPTION
## What does this change?

Uses the new 'Published Atom File' type for imports from The Media Atom Tool.

## How can we measure success?

Imported files should use the new type.

Tested on the dev. system.