### PR TITLE
Checklist Link

### DIFF
--- a/frontend/app/ProjectDeliverablesComponent.tsx
+++ b/frontend/app/ProjectDeliverablesComponent.tsx
@@ -27,6 +27,7 @@ import {
   TextField,
   Collapse,
   Tooltip,
+  Link,
 } from "@material-ui/core";
 import DeleteIcon from "@material-ui/icons/Delete";
 import EditIcon from "@material-ui/icons/Edit";
@@ -384,6 +385,12 @@ const ProjectDeliverablesComponent: React.FC<RouteComponentProps> = () => {
 
   const loadRecordCallback = useCallback(loadRecord, []);
 
+  const localOpenSelected = () => {
+    window.open(
+      `https://sites.google.com/guardian.co.uk/multimedia/final-project-delivery-checklist`
+    );
+  };
+
   return (
     <>
       {parentBundleInfo?.name ? (
@@ -418,6 +425,16 @@ const ProjectDeliverablesComponent: React.FC<RouteComponentProps> = () => {
             </p>
           )}
         </div>
+        <Link
+          style={{ cursor: "pointer" }}
+          onClick={() =>
+            window.open(
+              `https://sites.google.com/guardian.co.uk/multimedia/final-project-delivery-checklist`
+            )
+          }
+        >
+          Deliverable Files Checklist
+        </Link>
         <span className={classes.buttonContainer}>
           <Button
             className={classes.buttons}

--- a/frontend/app/ProjectDeliverablesComponent.tsx
+++ b/frontend/app/ProjectDeliverablesComponent.tsx
@@ -385,12 +385,6 @@ const ProjectDeliverablesComponent: React.FC<RouteComponentProps> = () => {
 
   const loadRecordCallback = useCallback(loadRecord, []);
 
-  const localOpenSelected = () => {
-    window.open(
-      `https://sites.google.com/guardian.co.uk/multimedia/final-project-delivery-checklist`
-    );
-  };
-
   return (
     <>
       {parentBundleInfo?.name ? (


### PR DESCRIPTION
## What does this change?

Adds a link to a checklist.

## How can we measure success?

The link is present on bundle pages.

## Images

![Screenshot 2024-02-28 at 15 39 21](https://github.com/guardian/pluto-deliverables/assets/10620802/d8f31522-8bfd-4ff6-a08f-8e2dd8a58f3f)

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2 and on the dev. system.
