### PR TITLE
Show Warning If the Video is Too Small

### DIFF
--- a/frontend/__tests__/TestMasterList.tsx
+++ b/frontend/__tests__/TestMasterList.tsx
@@ -53,6 +53,8 @@ describe("MasterList", () => {
         deliverable={deliverable}
         project_id={1}
         onSyndicationInitiated={mockOnSyndicationInitiated}
+        width={1000}
+        height={1000}
       />
     );
     const masterElements = wrapper
@@ -90,6 +92,8 @@ describe("MasterList", () => {
         deliverable={deliverable}
         project_id={2}
         onSyndicationInitiated={mockOnSyndicationInitiated}
+        width={1000}
+        height={1000}
       />
     );
 
@@ -207,6 +211,8 @@ describe("MasterList", () => {
         deliverable={deliverable}
         project_id={3}
         onSyndicationInitiated={mockOnSyndicationInitiated}
+        width={1000}
+        height={1000}
       />
     );
 

--- a/frontend/__tests__/TestMasterList.tsx
+++ b/frontend/__tests__/TestMasterList.tsx
@@ -53,8 +53,8 @@ describe("MasterList", () => {
         deliverable={deliverable}
         project_id={1}
         onSyndicationInitiated={mockOnSyndicationInitiated}
-        width={1000}
-        height={1000}
+        width={1920}
+        height={1080}
       />
     );
     const masterElements = wrapper
@@ -92,8 +92,8 @@ describe("MasterList", () => {
         deliverable={deliverable}
         project_id={2}
         onSyndicationInitiated={mockOnSyndicationInitiated}
-        width={1000}
-        height={1000}
+        width={1920}
+        height={1080}
       />
     );
 
@@ -211,8 +211,8 @@ describe("MasterList", () => {
         deliverable={deliverable}
         project_id={3}
         onSyndicationInitiated={mockOnSyndicationInitiated}
-        width={1000}
-        height={1000}
+        width={1920}
+        height={1080}
       />
     );
 

--- a/frontend/app/MasterList/MasterList.tsx
+++ b/frontend/app/MasterList/MasterList.tsx
@@ -256,7 +256,12 @@ const MasterList: React.FC<MasterListProps> = (props) => {
   };
 
   const checkSize = () => {
-    if ((props.deliverable.type == 1) || (props.deliverable.type == 2) || (props.deliverable.type == 14) || (props.deliverable.type == 16)) {
+    if (
+      props.deliverable.type == 1 ||
+      props.deliverable.type == 2 ||
+      props.deliverable.type == 14 ||
+      props.deliverable.type == 16
+    ) {
       if (props.width < 1280) {
         setTooSmall(true);
       }
@@ -264,7 +269,7 @@ const MasterList: React.FC<MasterListProps> = (props) => {
         setTooSmall(true);
       }
     }
-  }
+  };
 
   useEffect(() => {
     loadData();
@@ -352,10 +357,11 @@ const MasterList: React.FC<MasterListProps> = (props) => {
             {tooSmall ? (
               <TableRow>
                 <TableCell align="center" colSpan={10}>
-                  Video is too small for syndication at {props.width}x{props.height}!
+                  Video is too small for syndication at {props.width}x
+                  {props.height}!
                 </TableCell>
               </TableRow>
-                ):(null)}
+            ) : null}
             {masters.map((master, index) => (
               <TableRow key={index}>
                 <TableCell>

--- a/frontend/app/MasterList/MasterList.tsx
+++ b/frontend/app/MasterList/MasterList.tsx
@@ -88,6 +88,8 @@ interface MasterListProps {
   deliverable: Deliverable;
   project_id: number;
   onSyndicationInitiated: (assetId: bigint) => void | undefined;
+  width: number;
+  height: number;
 }
 
 const MasterList: React.FC<MasterListProps> = (props) => {
@@ -98,6 +100,7 @@ const MasterList: React.FC<MasterListProps> = (props) => {
   const [refreshTimerId, setRefreshTimerId] = useState<number | undefined>(
     undefined
   );
+  const [tooSmall, setTooSmall] = useState<boolean>(false);
 
   const [masters, setMasters] = useState<Master[]>([
     {
@@ -252,8 +255,20 @@ const MasterList: React.FC<MasterListProps> = (props) => {
     setMasters(updatedMasters);
   };
 
+  const checkSize = () => {
+    if ((props.deliverable.type == 1) || (props.deliverable.type == 2) || (props.deliverable.type == 14) || (props.deliverable.type == 16)) {
+      if (props.width < 1280) {
+        setTooSmall(true);
+      }
+      if (props.height < 720) {
+        setTooSmall(true);
+      }
+    }
+  }
+
   useEffect(() => {
     loadData();
+    checkSize();
   }, []);
 
   const getTypeImageSource = (master: Master) => {
@@ -334,6 +349,13 @@ const MasterList: React.FC<MasterListProps> = (props) => {
             </TableRow>
           </TableHead>
           <TableBody>
+            {tooSmall ? (
+              <TableRow>
+                <TableCell align="center" colSpan={10}>
+                  Video is too small for syndication at {props.width}x{props.height}!
+                </TableCell>
+              </TableRow>
+                ):(null)}
             {masters.map((master, index) => (
               <TableRow key={index}>
                 <TableCell>

--- a/frontend/app/MasterList/MasterList.tsx
+++ b/frontend/app/MasterList/MasterList.tsx
@@ -262,11 +262,13 @@ const MasterList: React.FC<MasterListProps> = (props) => {
       props.deliverable.type == 14 ||
       props.deliverable.type == 16
     ) {
-      if (props.width < 1280) {
-        setTooSmall(true);
-      }
-      if (props.height < 720) {
-        setTooSmall(true);
+      if (props.width != 0) {
+        if (props.width < 1280) {
+          setTooSmall(true);
+        }
+        if (props.height < 720) {
+          setTooSmall(true);
+        }
       }
     }
   };

--- a/frontend/app/ProjectDeliverables/DeliverableRow.tsx
+++ b/frontend/app/ProjectDeliverables/DeliverableRow.tsx
@@ -50,6 +50,8 @@ const DeliverableRow: React.FC<DeliverableRowProps> = (props) => {
   const [deliverable, setDeliverable] = useState<Deliverable>(
     props.deliverable
   );
+  const [width, setWidth] = useState<number>(0);
+  const [height, setHeight] = useState<number>(0);
 
   const updateVidispineItem = async () => {
     if (!deliverable.online_item_id) {
@@ -59,12 +61,22 @@ const DeliverableRow: React.FC<DeliverableRowProps> = (props) => {
       return;
     }
 
-    const url = `${props.vidispineBaseUri}/API/item/${deliverable.online_item_id}?content=metadata&field=__version,durationSeconds`;
+    const url = `${props.vidispineBaseUri}/API/item/${deliverable.online_item_id}?content=metadata&field=__version,durationSeconds,originalWidth,originalHeight`;
     try {
       const response = await axios.get(url);
       const item = new VidispineItem(response.data); //throws a VError if the data is not valid
       console.log("Got item data ", item);
       setVersion(item.getLatestVersion());
+
+      const loadedWidth = item.getMetadataString("originalWidth");
+      if (loadedWidth != undefined) {
+        setWidth(parseInt(loadedWidth));
+      }
+
+      const loadedHeight = item.getMetadataString("originalHeight");
+      if (loadedHeight != undefined) {
+        setHeight(parseInt(loadedHeight));
+      }
 
       const maybeDuration = item.getMetadataString("durationSeconds");
       try {
@@ -241,6 +253,8 @@ const DeliverableRow: React.FC<DeliverableRowProps> = (props) => {
               deliverable={deliverable}
               project_id={props.project_id}
               onSyndicationInitiated={props.onSyndicationStarted}
+              width={width}
+              height={height}
             />
           </Collapse>
         </TableCell>


### PR DESCRIPTION
## What does this change?

Show a warning if the video is too small.

## How can we measure success?

A warning is shown if the video is too small.

## Images

![Screenshot 2024-06-27 at 16 26 56](https://github.com/guardian/pluto-deliverables/assets/10620802/b6df43c1-a455-4eb0-afc4-6ec8efbb06d0)

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2 and on the dev. system.