### PR TITLE
Record the Source

### DIFF
--- a/gnm_deliverables/launch_detector.py
+++ b/gnm_deliverables/launch_detector.py
@@ -358,6 +358,7 @@ def update_gnmwebsite(msg: LaunchDetectorUpdate, asset: DeliverableAsset):
         rec.publication_status = 'Published'
     # set the etag in case something else is editing it at the moment
     rec.etag = zoned_datetime().isoformat('T')
+    rec.source = msg.source
 
     asset.gnm_website_master = rec  #no-op if it was already set like this
     rec.save()

--- a/gnm_deliverables/migrations/0021_manual.py
+++ b/gnm_deliverables/migrations/0021_manual.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('gnm_deliverables', '0020_manual'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='GNMWebsite',
+            name='source',
+            field=models.TextField(blank=True, null=True),
+        ),
+    ]

--- a/gnm_deliverables/models.py
+++ b/gnm_deliverables/models.py
@@ -513,6 +513,7 @@ class GNMWebsite(models.Model):
     primary_tone = models.TextField(null=True, blank=True, choices=PRIMARY_TONE, db_index=True)
     publication_status = models.TextField(null=True, blank=True, choices=PUBLICATION_STATUS)
     etag = models.DateTimeField(null=False, blank=False, auto_now_add=True)
+    source = models.TextField(null=True, blank=True)
 
 
 class Mainstream(models.Model):


### PR DESCRIPTION
## What does this change?

Records the source that is set in Media Atom Maker into the GNM Web Site model.

## How can we measure success?

The source field is recorded successfully.

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2 and on the dev. system.