### PR TITLE
Upgrading Pluto Headers

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -87,7 +87,7 @@
     "@fortawesome/free-regular-svg-icons": "^5.12.0",
     "@fortawesome/free-solid-svg-icons": "^5.12.0",
     "@fortawesome/react-fontawesome": "^0.1.8",
-    "@guardian/pluto-headers": "2.0.4",
+    "@guardian/pluto-headers": "2.1.1",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.58",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -417,10 +417,10 @@
   dependencies:
     prop-types "^15.7.2"
 
-"@guardian/pluto-headers@2.0.4":
-  version "2.0.4"
-  resolved "https://npm.pkg.github.com/download/@guardian/pluto-headers/2.0.4/5b5e2aa2fd7557dddf8e66c226fc1b0299455a64#5b5e2aa2fd7557dddf8e66c226fc1b0299455a64"
-  integrity sha512-9g/g0D+U08CT5sfSeNZDTR2C8xDTHEYzrhqEo+g8DDp67BCuf0Sc1tt2nrR+mJoz0z+jat2xUVIW/QJFniYmwA==
+"@guardian/pluto-headers@2.1.1":
+  version "2.1.1"
+  resolved "https://npm.pkg.github.com/download/@guardian/pluto-headers/2.1.1/cf8f63c25f46a15ab7c3c23b73e1c65230f07b1e#cf8f63c25f46a15ab7c3c23b73e1c65230f07b1e"
+  integrity sha512-AsAoCnQDS9V2RNMDJIdi6KlZaKUw8iczWH9lWyKwkS666p46H83O8+FBTceui1M1LKLNfQSV2MW/MyQUYOyC9Q==
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"


### PR DESCRIPTION
## What does this change?

Uses a version of Pluto Headers with a help button.

## How can we measure success?

The correct version of Pluto Headers is used.

## Images

![Screenshot 2024-12-19 at 13 24 46](https://github.com/user-attachments/assets/8dd3a8fc-2592-49eb-9d7a-2365e5a5ed1f)

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2 and on the dev. system.